### PR TITLE
[DOC] Change README title to the same format as the one in the Android App

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![OpenSSF Scorecard Score](https://api.scorecard.dev/projects/github.com/telekom/citykey-ios/badge)](https://scorecard.dev/viewer/?uri=github.com/telekom/citykey-ios/badge)
 
-# Citykey App (iOS Client)
+# iOS App of Citykey
 
 [![REUSE status](https://api.reuse.software/badge/github.com/telekom/CityKey-iOS)](https://api.reuse.software/info/github.com/telekom/CityKey-iOS)
 


### PR DESCRIPTION
This ``PR`` changes the ``README.md`` title to the one used in the [Android App repository](https://github.com/telekom/CityKey-Android/blob/fa3501ab1649cc87469393e521051425129de566/README.md). This ``PR`` hence improves consistency among the App repositories.