### PR TITLE
[DOC] Move openssf scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 ![Citykey App's Overview](./images/cover.png)
 
-[![OpenSSF Scorecard Score](https://api.scorecard.dev/projects/github.com/telekom/citykey-ios/badge)](https://scorecard.dev/viewer/?uri=github.com/telekom/citykey-ios/badge)
-
 # iOS App of Citykey
 
+[![OpenSSF Scorecard Score](https://api.scorecard.dev/projects/github.com/telekom/citykey-ios/badge)](https://scorecard.dev/viewer/?uri=github.com/telekom/citykey-ios/badge)
 [![REUSE status](https://api.reuse.software/badge/github.com/telekom/CityKey-iOS)](https://api.reuse.software/info/github.com/telekom/CityKey-iOS)
 
 ## Overview


### PR DESCRIPTION
This `PR` moves the `OpenSSF` Scorecard badge in the `README` below the first heading to be more consistent with the [Android repository](https://github.com/telekom/CityKey-Android/blob/e03364a1eeb73d4d4fe25d5abc5fff04db1833e4/README.md).