### PR TITLE
[BUILD] Add Open Source Software Review Toolkit workflow

### DIFF
--- a/.github/workflows/oss-review-toolkit.yml
+++ b/.github/workflows/oss-review-toolkit.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: CC0-1.0
+
 name: Open Source Software Review Toolkit (ORT)
 
 on:


### PR DESCRIPTION
This `PR` adds the `Open Source Software Review Toolkit (ORT)` workflow, which runs on all pushes with a version tag and periodically once a month.