### PR TITLE
[BUILD] Add continuous integration workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: CC0-1.0
+
 name: Continuous Integration (CI)
 
 on:


### PR DESCRIPTION
This `PR` adds the continuous integration workflow which runs on all pushes to main, on three pull request events, and can also be triggered manually.

The continuous integration workflow relies on `fastlane`.