### PR TITLE
[BUILD] Add swiftlint configuration file

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: CC0-1.0
+
 excluded:
   - Carthage
   - Pods


### PR DESCRIPTION
This `PR` adds the configuration file for [`swiftlint`](https://github.com/realm/SwiftLint/tree/main), which is used in the continuous integration workflow for linting.

The settings for file have been provided in one of the comments of `PR` #12.