### PR TITLE
[BUILD] Replace shortend commit SHA with full commit SHA to fix resolve action error

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,7 +33,7 @@ jobs:
           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
         - name: "Set up Xcode"
-          uses: mxcl/xcodebuild@2cf0ec52b855fa777531c5c89b714caa7 # v3.4.0
+          uses: mxcl/xcodebuild@2cf0ec52b855fa777531c5c89b714caa7a3abd5e # v3.4.0
           with:
             action: none
 
@@ -63,7 +63,7 @@ jobs:
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: "Set up Xcode"
-              uses: mxcl/xcodebuild@2cf0ec52b855fa777531c5c89b714caa7 # v3.4.0
+              uses: mxcl/xcodebuild@2cf0ec52b855fa777531c5c89b714caa7a3abd5e # v3.4.0
               with:
                 platform: ${{ matrix.platform }}
                 platform-version: ${{ matrix.platform-version }}
@@ -110,7 +110,7 @@ jobs:
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: "Build App in Debug Mode"
-              uses: mxcl/xcodebuild@2cf0ec52b855fa777531c5c89b714caa7 # v3.4.0
+              uses: mxcl/xcodebuild@2cf0ec52b855fa777531c5c89b714caa7a3abd5e # v3.4.0
               with:
                 platform: ${{ matrix.platform }}
                 platform-version: ${{ matrix.platform-version }}


### PR DESCRIPTION
This `PR` replaces the shortend commit SHA with the full commit SHA in the `continuous-integration` workflow.

To fix the resolve action error, which means that the required action version could not be located, this `PR` exchanges the shortend commit SHA with the full commit SHA in `continuous-integration` workflow.