### PR TITLE
[BUILD] Change swift-lint runner in continuous integration workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,7 @@ on:
 jobs:
 
     swift-lint:
-      runs-on: ubuntu-24.04
+      runs-on: macos-15
 
       steps:
         - name: "Checkout repository"


### PR DESCRIPTION
This `PR` changes the runner from `ubuntu-24.04` to `macos-15` of the `swift-lint` job to make `xcode-select` available in the runner - this fixes the error [here](https://github.com/MacOS/CityKey-iOS/actions/runs/13516201627/job/37765273104).