### PR TITLE
[BUILD] Add setup-ruby action to continuous integration workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -121,6 +121,12 @@ jobs:
             - name: "Checkout repository"
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+            - name: "Set up Ruby"
+              uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
+              with:
+                ruby-version: '3.0'
+                bundler-cache: true
+
             - name: "Build App in Debug Mode"
               uses: mxcl/xcodebuild@2cf0ec52b855fa777531c5c89b714caa7 # v3.4.0
               with:


### PR DESCRIPTION
This `PR` adds the `setup-ruby` action to the `continuouur-integration` workflow, which is needed for the `fastlane-action`.