### PR TITLE
[DOC] Add information header to all storyboards in directory OSCA/Screens

### DIFF
--- a/OSCA/Screens/AusweisAuthServices/AusweisAuth.storyboard
+++ b/OSCA/Screens/AusweisAuthServices/AusweisAuth.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="2B2-5Y-4ZA">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/AusweisAuthServices/AusweisAuthWorkflow.storyboard
+++ b/OSCA/Screens/AusweisAuthServices/AusweisAuthWorkflow.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="GvQ-uV-X2u">
     <device id="retina6_7" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/AusweisAuthServices/EgovServiceDetails.storyboard
+++ b/OSCA/Screens/AusweisAuthServices/EgovServiceDetails.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/BasicPOIGuide/Storyboard/BasicPOIGuide.storyboard
+++ b/OSCA/Screens/BasicPOIGuide/Storyboard/BasicPOIGuide.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="rpV-nh-SeW">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/BasicPOIGuide/Storyboard/BasicPOIGuideDetail.storyboard
+++ b/OSCA/Screens/BasicPOIGuide/Storyboard/BasicPOIGuideDetail.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aJH-fz-L9C">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/CitizenSurvey/View/CitizenSurvey.storyboard
+++ b/OSCA/Screens/CitizenSurvey/View/CitizenSurvey.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/CityImprint/Storyboard/CityImprintScreen.storyboard
+++ b/OSCA/Screens/CityImprint/Storyboard/CityImprintScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9Ga-aH-egm">
     <device id="retina4_7" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Dashboard/View/Base.lproj/Dashboard.storyboard
+++ b/OSCA/Screens/Dashboard/View/Base.lproj/Dashboard.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9Ga-aH-egm">
     <device id="retina6_0" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Dashboard/View/Base.lproj/NewsOverviewScreen.storyboard
+++ b/OSCA/Screens/Dashboard/View/Base.lproj/NewsOverviewScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="cad-xd-YKg">
     <device id="retina4_7" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/DataPrivacyFlow/Storyboard/DataPrivacyScreen.storyboard
+++ b/OSCA/Screens/DataPrivacyFlow/Storyboard/DataPrivacyScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="TgU-fQ-nlR">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/DefectReforter/Storyboard/DefectReporter.storyboard
+++ b/OSCA/Screens/DefectReforter/Storyboard/DefectReporter.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/DeleteAccountFlow/Storyboard/DeleteAccount.storyboard
+++ b/OSCA/Screens/DeleteAccountFlow/Storyboard/DeleteAccount.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="N6m-Ic-L56">
     <device id="retina5_9" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Events/View/EventDetailScreen.storyboard
+++ b/OSCA/Screens/Events/View/EventDetailScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="3FD-z7-QDp">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Events/View/EventsOverviewScreen.storyboard
+++ b/OSCA/Screens/Events/View/EventsOverviewScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="NXT-Rm-iId">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Events/View/MapViewScreen.storyboard
+++ b/OSCA/Screens/Events/View/MapViewScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="sKv-t9-3Az">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Events/View/SCEventLightBox.storyboard
+++ b/OSCA/Screens/Events/View/SCEventLightBox.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="2vc-oB-oPi">
     <device id="retina4_7" orientation="portrait">

--- a/OSCA/Screens/FahrradParken/storyboard/Fahrradparken.storyboard
+++ b/OSCA/Screens/FahrradParken/storyboard/Fahrradparken.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/InfoNotice/View/InfoNoticeScreen.storyboard
+++ b/OSCA/Screens/InfoNotice/View/InfoNoticeScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="TgU-fQ-nlR">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Location/View/Base.lproj/LocationScreen.storyboard
+++ b/OSCA/Screens/Location/View/Base.lproj/LocationScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ltD-mK-jgb">
     <device id="retina5_9" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Login/View/Base.lproj/LoginScreen.storyboard
+++ b/OSCA/Screens/Login/View/Base.lproj/LoginScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="yMn-ds-XaL">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Main/View/Base.lproj/Main.storyboard
+++ b/OSCA/Screens/Main/View/Base.lproj/Main.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
     <device id="retina4_7" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Marketplace/View/Base.lproj/MarketplaceOverviewScreen.storyboard
+++ b/OSCA/Screens/Marketplace/View/Base.lproj/MarketplaceOverviewScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="cad-xd-YKg">
     <device id="retina4_7" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Marketplace/View/Base.lproj/MarketplaceScreen.storyboard
+++ b/OSCA/Screens/Marketplace/View/Base.lproj/MarketplaceScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9Ga-aH-egm">
     <device id="retina4_7" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Profile/View/Base.lproj/EditProfileScreen.storyboard
+++ b/OSCA/Screens/Profile/View/Base.lproj/EditProfileScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="wsV-CP-Fcg">
     <device id="retina5_9" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Profile/View/Base.lproj/ProfileScreen.storyboard
+++ b/OSCA/Screens/Profile/View/Base.lproj/ProfileScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="x74-WS-Ojg">
     <device id="retina6_1" orientation="portrait" appearance="dark"/>

--- a/OSCA/Screens/Registration/View/Base.lproj/RegistrationScreen.storyboard
+++ b/OSCA/Screens/Registration/View/Base.lproj/RegistrationScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="jdq-NC-N2H">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Services/View/Base.lproj/ServicesInfoDetailScreen.storyboard
+++ b/OSCA/Screens/Services/View/Base.lproj/ServicesInfoDetailScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Services/View/Base.lproj/ServicesOverviewScreen.storyboard
+++ b/OSCA/Screens/Services/View/Base.lproj/ServicesOverviewScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="cad-xd-YKg">
     <device id="retina4_7" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/Services/View/Base.lproj/ServicesScreen.storyboard
+++ b/OSCA/Screens/Services/View/Base.lproj/ServicesScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9Ga-aH-egm">
     <device id="retina4_7" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/TEVIS/TEVIS.storyboard
+++ b/OSCA/Screens/TEVIS/TEVIS.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="arI-Rs-UJN">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/UserInfoBox/View/Base.lproj/UserInfoBoxScreen.storyboard
+++ b/OSCA/Screens/UserInfoBox/View/Base.lproj/UserInfoBoxScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="R7p-1s-Drt">
     <device id="retina4_7" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/UserInfoBox/View/UserInfoBoxDetailScreen.storyboard
+++ b/OSCA/Screens/UserInfoBox/View/UserInfoBoxDetailScreen.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oh6-Dc-OZ4">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/WasteCalendar/View/FTUWasteCalendar.storyboard
+++ b/OSCA/Screens/WasteCalendar/View/FTUWasteCalendar.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="IjW-JF-zNb">
     <device id="retina6_1" orientation="portrait" appearance="light"/>

--- a/OSCA/Screens/WasteCalendar/View/WasteCalendar.storyboard
+++ b/OSCA/Screens/WasteCalendar/View/WasteCalendar.storyboard
@@ -1,4 +1,4 @@
-/*
+<!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ These elements are not considered part of the licensed Work or Derivative Works 
 SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
 License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
-*/
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gsh-j8-zHC">
     <device id="retina6_1" orientation="portrait" appearance="light"/>


### PR DESCRIPTION
This `PR` adds the information header, which includes copyright and license information, to all `.storyboard` files in directory `OSCA/Screens`.

This `PR` adds the Deutsche Telekom information header to all `.storyboard` in directory `OSCA/Screens`. The information header includes the copyright and license information as required by the `REUSE` standard, and hence this `PR` has a positive effect on the `REUSE` evaluation.