### PR TITLE
[FIX] Bump rupy version in continuous-integration workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -124,7 +124,7 @@ jobs:
             - name: "Set up Ruby"
               uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
               with:
-                ruby-version: '3.0'
+                ruby-version: '3.4.2'
                 bundler-cache: true
 
             - name: "Build App in Debug Mode"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,7 +40,7 @@ jobs:
         - name: "Set up Ruby"
           uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
           with:
-            ruby-version: '3.0'
+            ruby-version: '3.4.2'
             bundler-cache: true
 
         - name: "Fastline SwiftLint"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -78,7 +78,7 @@ jobs:
             - name: "Set up Ruby"
               uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
               with:
-                ruby-version: '3.0'
+                ruby-version: '3.4.2'
                 bundler-cache: true
 
             - name: "Run fastlane unit tests with coverage"


### PR DESCRIPTION
This `PR` bumps the ruby version to `3.4.2` in all jobs in the `continuous-integration` workflow.

This `PR` fixes the following error, caused by an outdated `ruby` version.
```
ERROR:  Error installing bundler:
  	bundler-2.6.2 requires Ruby version >= 3.1.0. The current ruby version is 3.0.7.220.
```