### PR TITLE
[DOC] Fix broken link in openssf scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # iOS App of Citykey
 [![Apache-2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](https://opensource.org/license/apache-2-0) 
-[![OpenSSF Scorecard Score](https://api.scorecard.dev/projects/github.com/telekom/citykey-ios/badge)](https://scorecard.dev/viewer/?uri=github.com/telekom/citykey-ios/badge)
+[![OpenSSF Scorecard Score](https://api.scorecard.dev/projects/github.com/telekom/CityKey-iOS/badge)](https://scorecard.dev/viewer/?uri=github.com/telekom/CityKey-iOS/badge)
 [![REUSE status](https://api.reuse.software/badge/github.com/telekom/CityKey-iOS)](https://api.reuse.software/info/github.com/telekom/CityKey-iOS)
 
 ## Overview


### PR DESCRIPTION
This `PR` changes the broken link in the `OpenSSF Scorecard Badge` by capitalizing the `URL` correctly.

As a result of this `PR`, the error `invalid repo path` should be gone.